### PR TITLE
Video streaming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.data:spring-data-mongodb:4.2.0'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.data:spring-data-mongodb:4.2.0'
+	implementation 'org.mongodb:mongodb-driver-sync:4.11.1'
+
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/MongoConfig.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/MongoConfig.java
@@ -1,6 +1,5 @@
 package com.mgiang2015.SpringVideoPlatform;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/MongoConfig.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/MongoConfig.java
@@ -1,0 +1,26 @@
+package com.mgiang2015.SpringVideoPlatform;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+
+// allows MongoDB to set up client
+@Configuration
+public class MongoConfig extends AbstractMongoClientConfiguration {
+
+    @Value("${spring.data.mongodb.database}")
+    private String databaseName;
+
+    @Bean
+    public GridFsTemplate gridFsTemplate() throws Exception {
+        return new GridFsTemplate(mongoDbFactory(), mappingMongoConverter(null, null, null));
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return databaseName;
+    }
+}

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/controller/VideoDataController.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/controller/VideoDataController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.mgiang2015.SpringVideoPlatform.services.VideoService;
+import com.mgiang2015.SpringVideoPlatform.services.VideoDataService;
 import com.mgiang2015.SpringVideoPlatform.model.VideoData;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,14 +20,20 @@ import jakarta.servlet.http.HttpServletResponse;
 public class VideoDataController {
     
     @Autowired
-    private VideoService service;
+    private VideoDataService service;
 
-    @PostMapping("/video/add")
+    @PostMapping("/videos/add")
     public String addVideo(@RequestParam("title") String title, @RequestParam("file") MultipartFile file) throws IOException {
         String id = service.addVideo(title, file);
         return id.toString();
     }
 
+    @GetMapping("/videos/details/{id}")
+    public VideoData getVideo(@PathVariable String id) throws IllegalStateException, IOException {
+        VideoData data = service.getVideo(id);
+        return data;
+    }
+    
     @GetMapping("/videos/stream/{id}")
     public void streamVideo(@PathVariable String id, HttpServletResponse response) throws IOException {
         VideoData data = service.getVideo(id);

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/controller/VideoDataController.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/controller/VideoDataController.java
@@ -1,0 +1,36 @@
+package com.mgiang2015.SpringVideoPlatform.controller;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.mgiang2015.SpringVideoPlatform.controller.services.VideoService;
+import com.mgiang2015.SpringVideoPlatform.model.VideoData;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@RestController
+public class VideoDataController {
+    
+    @Autowired
+    private VideoService service;
+
+    @PostMapping("/video/add")
+    public String addVideo(@RequestParam("title") String title, @RequestParam("file") MultipartFile file) throws IOException {
+        String id = service.addVideo(title, file);
+        return id.toString();
+    }
+
+    @GetMapping("/videos/stream/{id}")
+    public void streamVideo(@PathVariable String id, HttpServletResponse response) throws IOException {
+        VideoData data = service.getVideo(id);
+        FileCopyUtils.copy(data.getStream(), response.getOutputStream());
+    }
+}

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/controller/VideoDataController.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/controller/VideoDataController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.mgiang2015.SpringVideoPlatform.controller.services.VideoService;
+import com.mgiang2015.SpringVideoPlatform.services.VideoService;
 import com.mgiang2015.SpringVideoPlatform.model.VideoData;
 
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/model/VideoData.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/model/VideoData.java
@@ -1,0 +1,29 @@
+package com.mgiang2015.SpringVideoPlatform.model;
+
+import java.io.InputStream;
+
+/** 
+ * Actual video data that will be stored in MongoDB
+*/
+public class VideoData {
+    private String title;
+    private InputStream stream;
+    public String getTitle() {
+        return title;
+    }
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public InputStream getStream() {
+        return stream;
+    }
+    public void setStream(InputStream stream) {
+        this.stream = stream;
+    }
+    @Override
+    public String toString() {
+        return "VideoData [title=" + title + ", stream=" + stream + "]";
+    }
+
+    
+}

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/services/VideoDataService.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/services/VideoDataService.java
@@ -17,7 +17,7 @@ import com.mongodb.DBObject;
 import com.mongodb.client.gridfs.model.GridFSFile;
 
 @Service
-public class VideoService {
+public class VideoDataService {
     
     @Autowired
     private GridFsTemplate gridFsTemplate;

--- a/src/main/java/com/mgiang2015/SpringVideoPlatform/services/VideoService.java
+++ b/src/main/java/com/mgiang2015/SpringVideoPlatform/services/VideoService.java
@@ -1,0 +1,44 @@
+package com.mgiang2015.SpringVideoPlatform.services;
+
+import java.io.IOException;
+
+import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.gridfs.GridFsOperations;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.mgiang2015.SpringVideoPlatform.model.VideoData;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.client.gridfs.model.GridFSFile;
+
+@Service
+public class VideoService {
+    
+    @Autowired
+    private GridFsTemplate gridFsTemplate;
+
+    @Autowired
+    private GridFsOperations operations;
+    
+    public String addVideo(String title, MultipartFile file) throws IOException {
+        DBObject metaData = new BasicDBObject();
+        metaData.put("type", "video");
+        metaData.put("title", title);
+        metaData.put("fileSize", file.getSize());
+        ObjectId id = gridFsTemplate.store(file.getInputStream(), file.getName(), file.getContentType(), metaData);
+        return id.toString();
+    }
+
+    public VideoData getVideo(String id) throws IllegalStateException, IOException {
+        GridFSFile file = gridFsTemplate.findOne(new Query(Criteria.where("_id").is(id)));
+        VideoData videoData = new VideoData();
+        videoData.setTitle(file.getMetadata().get("title").toString());
+        videoData.setStream(operations.getResource(file).getInputStream());
+        return videoData;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
-
+# add connection below
+# spring.data.mongodb.uri=mongodb+srv://<username>:<password>@videodb.xlmxyvz.mongodb.net/?retryWrites=true&w=majority
+spring.servlet.multipart.enabled = true
+spring.servlet.multipart.max-file-size = 200MB
+spring.servlet.multipart.max-request-size = 200MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 # add connection below
-# spring.data.mongodb.uri=mongodb+srv://<username>:<password>@videodb.xlmxyvz.mongodb.net/?retryWrites=true&w=majority
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=spring-video-platform
 spring.servlet.multipart.enabled = true
 spring.servlet.multipart.max-file-size = 200MB
 spring.servlet.multipart.max-request-size = 200MB


### PR DESCRIPTION
Add end-points for video upload and download
`POST /videos/add` allows uploading video file to MongoDB
`GET /videos/stream/{id}` allows streaming video to client as InputStream (binary)
`GET /videos/data/{id}` allows retrieving video's metadata